### PR TITLE
Add --hacktoberfest flag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ gfi gql "rust-lang" --repo "rust"
 gfi gql "sindresorhus" --repo "awesome"
 ```
 
+**Query repositories with topic 'hacktoberfest'**
+
+```bash
+# Query all repos with topic 'hacktoberfest'
+gfi gql --hacktoberfest
+
+# Query all repos with topic 'hacktoberfest' in an organization or in a user profile
+# No --user flag needed for user.
+gfi gql "facebook" --hacktoberfest
+gfi gql "yankeexe" --hacktoberfest
+```
+
 **Changing output limits**
 
 The output is limited to display 10 issues by default. Use `--limit` flag to set the number of issues for output or `--all` for no limits.

--- a/good_first_issues/graphql/commands.py
+++ b/good_first_issues/graphql/commands.py
@@ -52,7 +52,7 @@ def gql(name: str, repo: str, user: bool, web: bool, limit: int, all: bool, hack
     """
 
     if name is None and hacktoberfest is False:
-        click.echo("Missing Argument NAME")
+        console.print("Error: Missing Argument NAME", style="bold red")
         raise click.Abort()
 
     issues: Optional[Iterable] = None

--- a/good_first_issues/graphql/commands.py
+++ b/good_first_issues/graphql/commands.py
@@ -20,7 +20,7 @@ console = Console(color_system="auto")
     type=str,
 )
 @click.option(
-    "--hacktoberfest",
+    "--hacktoberfest","--hf",
     help="Search repositories with topic hacktoberfest",
     is_flag=True,
 )

--- a/good_first_issues/graphql/queries.py
+++ b/good_first_issues/graphql/queries.py
@@ -69,6 +69,31 @@ query getIssues($name: String!, $owner: String!) {
 }
 """
 
+search_query: str = """
+query search($queryString: String!){
+  search(type: REPOSITORY, query: $queryString, first: 50) {
+    edges {
+      node {
+        ... on Repository {
+          url
+          issues(filterBy: { states: OPEN, labels: "good first issue" }, first: 100) {
+            edges {
+            node {
+                  title
+                  url
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+      remaining
+    }
+}
+"""
+
 rate_limit_query: str = """
 {
   rateLimit {

--- a/good_first_issues/graphql/services.py
+++ b/good_first_issues/graphql/services.py
@@ -170,7 +170,7 @@ def identify_mode(name: str, repo: str, user: bool, hacktoberfest: bool) -> Tupl
         mode="search"
 
     if repo and hacktoberfest:
-        spinner.fail("--hacktoberfest cannot be used with --repo flag")
+        spinner.fail("--hacktoberfest or --hf cannot be used with --repo flag")
 
     return query, variables, mode
 

--- a/good_first_issues/graphql/services.py
+++ b/good_first_issues/graphql/services.py
@@ -170,7 +170,8 @@ def identify_mode(name: str, repo: str, user: bool, hacktoberfest: bool) -> Tupl
         mode="search"
 
     if repo and hacktoberfest:
-        spinner.fail("--hacktoberfest or --hf cannot be used with --repo flag")
+        console.print("Error: --hacktoberfest or --hf cannot be used with --repo flag", style="bold red")
+        sys.exit()
 
     return query, variables, mode
 

--- a/good_first_issues/graphql/services.py
+++ b/good_first_issues/graphql/services.py
@@ -169,6 +169,9 @@ def identify_mode(name: str, repo: str, user: bool, hacktoberfest: bool) -> Tupl
             variables["queryString"]+=f'user:{name}'
         mode="search"
 
+    if repo and hacktoberfest:
+        spinner.fail("--hacktoberfest cannot be used with --repo flag")
+
     return query, variables, mode
 
 


### PR DESCRIPTION
fixes #13 

Have added --hacktoberfest flag feature which filters repositories with topic **hacktoberfest**

1. gfi gql --hacktoberfest

Lists 'good first issues' from all repositories with topic 'hacktoberfest' 

![image](https://user-images.githubusercontent.com/5791109/95404352-6b692600-0932-11eb-89e1-4768de07aa2f.png)

2. gfi gql "facebook" --hacktoberfest

Lists 'good first issues' from all repositories with topic 'hacktoberfest' in an organisation

![image](https://user-images.githubusercontent.com/5791109/95404492-d0bd1700-0932-11eb-8c7b-52f6aebd096d.png)

3. gfi gql "yankeexe" --hacktoberfest

Lists 'good first issues' from all repositories with topic 'hacktoberfest' in a user profile

![image](https://user-images.githubusercontent.com/5791109/95404550-fc400180-0932-11eb-92f1-cd33470b0838.png)

The above commands work with --hf flag also.

